### PR TITLE
Allow custom product value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Initialize a Spoor client with options:
 | `req`        | The default Express request for all events. *Required in constructor or `submit`*.     |
 | `source`     | String to tell Spoor where the event came from. *Required in constructor or `submit`*. |
 | `category`   | String for Spoor event categorisation. *Required in constructor or `submit`*.          |
+| `product`    | String for Spoor `context.product`. Defaults to `"next"`.                              |
 | `apiKey`     | Defaults to `process.env.SPOOR_API_KEY`                                                |
 | `submitIf`   | Boolean. If false, the client will not submit events.                                  |
 | `inTestMode` | Boolean. Sets a context flag to tell Spoor the event is a test event.                  |
@@ -48,15 +49,15 @@ Initialize a Spoor client with options:
 
 Send an event to Spoor. Returns a promise which resolves when the event is successfully sent to Spoor, or rejects with a status object when submission fails. The event should be an object with keys:
 
-| Option       | Description                                                                            |
-|--------------|----------------------------------------------------------------------------------------|
-| `req`        | The default Express request for all events. *Required in constructor or `submit`*.     |
-| `source`     | String to tell Spoor where the event came from. *Required in constructor or `submit`*. |
-| `category`   | String for Spoor event categorisation. *Required in constructor or `submit`*.          |
-| `action`     | String name of the event action.                                                       |
-| `context`    | Object containing metadata pertaining to the event. *Required*.                        |
-| `apiKey`     | Defaults to `process.env.SPOOR_API_KEY`                                                |
-
+| Option       | Description                                                                                                                      |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `req`        | The default Express request for all events. *Required in constructor or `submit`*.                                               |
+| `source`     | String to tell Spoor where the event came from. *Required in constructor or `submit`*.                                           |
+| `category`   | String for Spoor event categorisation. *Required in constructor or `submit`*.                                                    |
+| `action`     | String name of the event action.                                                                                                 |
+| `context`    | Object containing metadata pertaining to the event. *Required*.                                                                  |
+| `apiKey`     | Defaults to `process.env.SPOOR_API_KEY`                                                                                          |
+| `product`    | String for Spoor `context.product`. Defaults to the SpoorClient constructor `product` value, which in turn defaults to `"next"`. |
 ---
 
 Originally part of [next-signup](https://github.com/Financial-Times/next-signup).

--- a/src/index.js
+++ b/src/index.js
@@ -13,19 +13,21 @@ export default class SpoorClient {
 		req,
 		source,
 		category,
+		product='next',
 		submitIf=true,
 		inTestMode=false,
 		apiKey=process.env.SPOOR_API_KEY
 	}={}) {
 		this.source = source;
 		this.category = category;
+		this.product = product;
 		this.req = req;
 		this.shouldSubmitEvent = submitIf;
 		this.apiKey = apiKey;
 		this.inTestMode = inTestMode;
 	}
 
-	submit ({source=this.source, category=this.category, req=this.req, apiKey=this.apiKey, action, context}={}) {
+	submit ({source=this.source, category=this.category, req=this.req, apiKey=this.apiKey, product=this.product, action, context}={}) {
 
 		logger.info('spoor -> will send event? ->', JSON.stringify({
 			category,
@@ -35,7 +37,7 @@ export default class SpoorClient {
 		}));
 
 		if(this.shouldSubmitEvent) {
-			context.product = 'next';
+			context.product = context.product || product;
 			context.isTestEvent = this.inTestMode;
 
 			const the = {


### PR DESCRIPTION
Defaults to "next".
It is possible to assign it on init, or in the submit event.
If not set in the submit event, will fallback to spoorClient init
value, and if not set there will fallback to "next" default.
