### PR TITLE
rename everything to spoor-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@financial-times/n-spoor-client",
+  "name": "@financial-times/spoor-client",
+  "version": "1.2.0",
   "description": "Javascript client for the Spoor API",
   "main": "lib/index.js",
   "files": [
@@ -15,7 +16,6 @@
     "url": "https://github.com/Financial-Times/n-spoor-client.git"
   },
   "author": "Ifeanyi Isitor",
-  "version": "1.2.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Financial-Times/n-spoor-client/issues"

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,17 @@
-n-spoor-client [![Build Status](https://travis-ci.org/Financial-Times/n-spoor-client.svg?branch=master)](https://travis-ci.org/Financial-Times/n-spoor-client)
+spoor-client [![Build Status](https://travis-ci.org/Financial-Times/spoor-client.svg?branch=master)](https://travis-ci.org/Financial-Times/spoor-client)
 ==============
 
 Node client to send events to [Spoor](https://spoor-docs.herokuapp.com/)
 
 ```shell
-npm install -S @financial-times/n-spoor-client
+npm install -S @financial-times/spoor-client
 ```
 
 Usage
 -----
 
 ```js
-import SpoorClient from '@financial-times/n-spoor-client';
+import SpoorClient from '@financial-times/spoor-client';
 
 function expressRoute(req, res) {
   const spoor = new SpoorClient({req});

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ describe('Spoor client', () => {
 		.reply(202, {});
 
 		const client = new SpoorClient({
-			source: 'n-spoor-client',
+			source: 'spoor-client',
 			category: 'test',
 			req: fakeRequest({
 				'ft-cookie-original': 'original cookie val; spoor-id=12345;',
@@ -54,7 +54,7 @@ describe('Spoor client', () => {
 		.reply(202, {});
 
 		const client = new SpoorClient({
-			source: 'n-spoor-client',
+			source: 'spoor-client',
 			category: 'test',
 			cookies: 'original cookie val; spoor-id=12345;',
 			ua: 'original ua val',


### PR DESCRIPTION
- [x] Rename repo
- [x] Tag 2.0 and publish under new name
- [x] Fix Travis
- [x] Deprecate old name (`npm deprecate @financial-times/n-spoor-client@1.x "renamed to @financial-times/spoor-client`)
- [x] maybe re-release old versions under new package name?
