### PR TITLE
Add spoor-id pass through via FT-Spoor-ID header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,10 @@ export default class SpoorClient {
 		context = {},
 		action
 	} = {}) {
-
 		cookies = cookies || (req && req.get('ft-cookie-original'));
 		ua = ua || (req && req.get('user-agent'));
 		ip = ip || (req && (req.get('fastly-client-ip') || req.ip));
-		deviceId = deviceId || extractSpoorId(cookies);
+		deviceId = deviceId || (req && (req.get('FT-Spoor-ID'))) || extractSpoorId(cookies);
 
 		logger.info('spoor -> will send event? -> ' + JSON.stringify({
 			category,

--- a/test.js
+++ b/test.js
@@ -111,6 +111,33 @@ describe('Spoor client', () => {
 		});
 	});
 
+	it('should send an event to Spoor using a header-provided device id', () => {
+		const fakeSpoorId = 'abcdef12456790';
+		const scope = nock('https://spoor-api.ft.com/', {
+			reqheaders: {
+				'spoor-id': fakeSpoorId,
+			},
+		})
+		.post('/ingest')
+		.reply(202, {});
+
+		const client = new SpoorClient({
+			source: 'spoor-client',
+			category: 'test',
+			req: fakeRequest({
+				'FT-Spoor-ID': fakeSpoorId
+			}),
+		});
+
+		return client.submit({
+			action: 'test',
+			context: {},
+		}).then(() => {
+			console.assert(scope.isDone(), 'should have sent event');
+		});
+
+	});
+
 	it('should use the client IP from request', () => {
 		const scope = nock('https://spoor-api.ft.com/')
 		.post('/ingest', {


### PR DESCRIPTION
## Description

Add the ability to pass the deviceId/SpoorId via the `FT-Spoor-ID` header, allowing spoor-ids to be passed from the client to the server in absence of the cookie or direct reference. This is important for services behind Fastly, where the cookies are stripped and not passed on.
