### PR TITLE
Add request tracing functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@financial-times/n-logger": "^5.3.0",
-    "node-fetch": "^1.5.1"
+    "node-fetch": "^1.5.1",
+    "uuid": "^2.0.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import uuid from 'uuid';
 import logger from '@financial-times/n-logger';
 
 const userIdPattern = /spoor-id=([^;]*)/;
@@ -20,6 +21,7 @@ export default class SpoorClient {
 		submitIf = true,
 		inTestMode = false,
 		deviceId = null,
+		requestId = null,
 		apiKey = process.env.SPOOR_API_KEY
 	} = {}) {
 		this.source = source;
@@ -33,6 +35,7 @@ export default class SpoorClient {
 		this.apiKey = apiKey;
 		this.inTestMode = inTestMode;
 		this.deviceId = deviceId;
+		this.requestId = requestId;
 	}
 
 	submit ({
@@ -45,6 +48,7 @@ export default class SpoorClient {
 		apiKey = this.apiKey,
 		product = this.product,
 		deviceId = this.deviceId,
+		requestId = this.requestId,
 		context = {},
 		action
 	} = {}) {
@@ -52,6 +56,7 @@ export default class SpoorClient {
 		ua = ua || (req && req.get('user-agent'));
 		ip = ip || (req && (req.get('fastly-client-ip') || req.ip));
 		deviceId = deviceId || (req && (req.get('FT-Spoor-ID'))) || extractSpoorId(cookies);
+		requestId = requestId || uuid.v4();
 
 		logger.info('spoor -> will send event? -> ' + JSON.stringify({
 			category,
@@ -99,7 +104,8 @@ export default class SpoorClient {
 					'Cookie': cookies,
 					'User-Agent': ua,
 					'Content-Length': new Buffer(JSON.stringify(the.data)).length,
-					'spoor-id': deviceId
+					'spoor-id': deviceId,
+					'spoor-ticket': requestId
 				},
 				body: JSON.stringify(the.data)
 			})

--- a/test.js
+++ b/test.js
@@ -138,6 +138,29 @@ describe('Spoor client', () => {
 
 	});
 
+	it('should send an event to Spoor using explicit request id', () => {
+		const scope = nock('https://spoor-api.ft.com/', {
+			reqheaders: {
+				'spoor-ticket': '12345',
+			},
+		})
+		.post('/ingest')
+		.reply(202, {});
+
+		const client = new SpoorClient({
+			source: 'spoor-client',
+			category: 'test',
+			requestId: '12345',
+		});
+
+		return client.submit({
+			action: 'test',
+			context: {},
+		}).then(() => {
+			console.assert(scope.isDone(), 'should have sent event');
+		});
+	});
+
 	it('should use the client IP from request', () => {
 		const scope = nock('https://spoor-api.ft.com/')
 		.post('/ingest', {

--- a/test.js
+++ b/test.js
@@ -150,7 +150,7 @@ describe('Spoor client', () => {
 		const client = new SpoorClient({
 			source: 'spoor-client',
 			category: 'test',
-			requestId: '12345',
+			spoorTicket: '12345',
 		});
 
 		return client.submit({


### PR DESCRIPTION
To ascertain whether the new `deviceId` fixes are working correctly we need to trace spoor requests through the system. Fortunately the Spoor API supports request tracing via a `spoor-ticket` header (read [docs](http://spoor-docs.herokuapp.com/usage#tracing) for further info).

This adds the ability to either pass an existing request Id or generate one for each request.

/cc @commuterjoy 
